### PR TITLE
Custom 404

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,8 +56,3 @@ theme = "hugo-hero-theme"
   post = "/:year/:month/:day/:slug/"
   blog = "/:year/:month/:slug/"
   pages = "/:filename/"
-
-[[redirects]]
-  from = "/*"
-  to = "/404/"
-  status = 404

--- a/config.toml
+++ b/config.toml
@@ -59,5 +59,5 @@ theme = "hugo-hero-theme"
 
 [[redirects]]
   from = "/*"
-  to = "/404"
+  to = "/404/"
   status = 404

--- a/netlify.toml
+++ b/netlify.toml
@@ -34,3 +34,8 @@ HUGO_VERSION = "0.92.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
+
+[[redirects]]
+  from = "/*"
+  to = "/404/"
+  status = 404


### PR DESCRIPTION
[[redirects]] was missing a trailing '/' on "to" parameter. Not sure if that's why netlify isn't serving the custom 404 or not, but here's the test.